### PR TITLE
InfInt bug when constructing with INT_MIN

### DIFF
--- a/InfInt.h
+++ b/InfInt.h
@@ -242,7 +242,9 @@ inline InfInt::InfInt(int l) : pos(l >= 0)
 {
     if (!pos)
     {
-        l = -l;
+        // avoid corner case for INT_MIN by adding one
+        // and undoing it later
+        l = -(l+1);
     }
     do
     {
@@ -250,13 +252,22 @@ inline InfInt::InfInt(int l) : pos(l >= 0)
         val.push_back((ELEM_TYPE) dt.rem);
         l = dt.quot;
     } while (l > 0);
+
+    // undo the operation made when handling the corner case
+    if (!pos)
+    {
+        // since pos = false, this is equivalent to subtracting 1
+        val[0] += 1;
+    }
 }
 
 inline InfInt::InfInt(long l) : pos(l >= 0)
 {
     if (!pos)
     {
-        l = -l;
+        // avoid corner case for LONG_MIN by adding one
+        // and undoing it later
+        l = -(l+1);
     }
     do
     {
@@ -264,13 +275,21 @@ inline InfInt::InfInt(long l) : pos(l >= 0)
         val.push_back((ELEM_TYPE) dt.rem);
         l = dt.quot;
     } while (l > 0);
+    // undo the operation made when handling the corner case
+    if (!pos)
+    {
+        // since pos = false, this is equivalent to subtracting 1
+        val[0] += 1;
+    }
 }
 
 inline InfInt::InfInt(long long l) : pos(l >= 0)
 {
     if (!pos)
     {
-        l = -l;
+        // avoid corner case for LONG_LONG_MIN by adding one
+        // and undoing it later
+        l = -(l+1);
     }
     do
     {
@@ -283,6 +302,12 @@ inline InfInt::InfInt(long long l) : pos(l >= 0)
         l = l / BASE;
 #endif
     } while (l > 0);
+    // undo the operation made when handling the corner case
+    if (!pos)
+    {
+        // since pos = false, this is equivalent to subtracting 1
+        val[0] += 1;
+    }
 }
 
 inline InfInt::InfInt(unsigned int l) : pos(true)

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 #include "InfInt.h"
 
 #include <assert.h>
+#include <limits.h>
 
 InfInt fib(InfInt n)
 {
@@ -34,6 +35,20 @@ void testInfInteger()
 	for (int i = 0; i < 100; ++i)
 	{
 		InfInt i1, i2;
+		{
+			// test that '==' works for edge conditions
+			assert(InfInt(INT_MIN) == INT_MIN);
+			// but also test the same with toInt because
+			// a bug in InfInt constructors can be masked
+			// with the '==' test
+			assert(InfInt(INT_MIN).toInt() == INT_MIN);
+			// do the same for long
+			assert(InfInt(LONG_MIN) == LONG_MIN);
+			assert(InfInt(LONG_MIN).toLong() == LONG_MIN);
+			// and long long
+			assert(InfInt(LONG_LONG_MIN) == LONG_LONG_MIN);
+			assert(InfInt(LONG_LONG_MIN).toLongLong() == LONG_LONG_MIN);
+		}
 		{
 			i1 = myint1++;
 			assert(i1-- == myint1-1);


### PR DESCRIPTION
There is a bug in InfInt representing INT_MIN, LONG_MIN, and LONG_LONG_MIN when using the constructor.  This is because multiplying those values by -1 causes an overflow.
