### PR TITLE
Fix multiple definitions if included more than once

### DIFF
--- a/InfInt.h
+++ b/InfInt.h
@@ -105,16 +105,16 @@ private:
     std::string txt;
 };
 
-InfIntException::InfIntException(const std::string& txt) throw () :
+inline InfIntException::InfIntException(const std::string& txt) throw () :
 std::exception(), txt(txt)
 {
 }
 
-InfIntException::~InfIntException() throw ()
+inline InfIntException::~InfIntException() throw ()
 {
 }
 
-const char* InfIntException::what() const throw ()
+inline const char* InfIntException::what() const throw ()
 {
     return txt.c_str();
 }
@@ -219,9 +219,11 @@ private:
     bool pos; // true if number is positive
 };
 
+#ifndef INFINT_STATICS_DECLARED
 const InfInt InfInt::zero = 0;
 const InfInt InfInt::one = 1;
 const InfInt InfInt::two = 2;
+#endif
 
 inline InfInt::InfInt() : pos(true)
 {


### PR DESCRIPTION
In my project [Rational](https://github.com/velnias75/rational) I've included `InfInt.h` twice in two compilation units, causing multiple definitions of both the `InfIntException` and the static constants.
- the `InfIntException` was easy to fix, by just _inlining_ them
- the constants I had to enclose with a _define_ `INFINT_STATICS_DECLARED` and defining it before I include it again.

I found some more small problems for which I will open issuses, but overall all test cases in [Rational](https://github.com/velnias75/rational) are succeeding :smile_cat:
