### PR TITLE
Fix Some Errors

### DIFF
--- a/InfInt.h
+++ b/InfInt.h
@@ -45,9 +45,9 @@
 //#include <stdlib.h>
 
 #ifdef _WIN32
-#define LONG_LONG_MIN LLONG_MIN
-#define LONG_LONG_MAX LLONG_MAX
-#define ULONG_LONG_MAX ULLONG_MAX
+// #define LONG_LONG_MIN LLONG_MIN
+// #define LONG_LONG_MAX LLONG_MAX
+// #define ULONG_LONG_MAX ULLONG_MAX
 #endif
 
 #ifdef INFINT_USE_EXCEPTIONS

--- a/InfInt.h
+++ b/InfInt.h
@@ -336,7 +336,7 @@ inline InfInt::InfInt(unsigned long long l) : pos(true)
     } while (l > 0);
 }
 
-inline InfInt::InfInt(const InfInt& l) : pos(l.pos), val(l.val)
+inline InfInt::InfInt(const InfInt& l) : val(l.val), pos(l.pos)
 {
     //PROFINY_SCOPE
 }

--- a/main.cpp
+++ b/main.cpp
@@ -134,7 +134,7 @@ void testInfInteger()
     assert(InfInt(9).intSqrt() == 3);
 }
 
-int main(int argc, const char * argv[])
+int main(void)
 {
     //PROFINY_SCOPE
     //testInfInteger();


### PR DESCRIPTION
When call g++ with "-Wall -Wextra -Werror" flags, many errors occurs:

- **In main.cpp =>** _'Unused parameter' :_

> Replace "int argc, const char * argv[]" by "void"

- **In InfInt.h =>** _'Redefined error' :_

> Comment LONG_LONG_MIN, LONG_LONG_MAX & ULONG_LONG_MAX defines

- **In InfInt.h =>** _'Will be initialized after' :_

> Flip "pos(l.pos)" and "val(l.val)"